### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,26 +1,26 @@
 #######################################
 # Data type (DATA_TYPE)
 #######################################
-Timeline            DATA_TYPE
-Button              DATA_TYPE
-LED                 DATA_TYPE
-TimeSwitch          DATA_TYPE
-fastdelegate        DATA_TYPE
-milliseconds        DATA_TYPE
-pinNum              DATA_TYPE
-inputId             DATA_TYPE
-IntRange            DATA_TYPE
-FloatRange          DATA_TYPE
-MillisecondRange    DATA_TYPE
+Timeline	DATA_TYPE
+Button	DATA_TYPE
+LED	DATA_TYPE
+TimeSwitch	DATA_TYPE
+fastdelegate	DATA_TYPE
+milliseconds	DATA_TYPE
+pinNum	DATA_TYPE
+inputId	DATA_TYPE
+IntRange	DATA_TYPE
+FloatRange	DATA_TYPE
+MillisecondRange	DATA_TYPE
 
-Back                DATA_TYPE
-BounceOut           DATA_TYPE
-Exponential         DATA_TYPE
-Flicker             DATA_TYPE
-Quadratic           DATA_TYPE
-Quantic             DATA_TYPE
-Sine                DATA_TYPE
-Tween               DATA_TYPE
+Back	DATA_TYPE
+BounceOut	DATA_TYPE
+Exponential	DATA_TYPE
+Flicker	DATA_TYPE
+Quadratic	DATA_TYPE
+Quantic	DATA_TYPE
+Sine	DATA_TYPE
+Tween	DATA_TYPE
 
 
 #######################################
@@ -41,21 +41,21 @@ Tween               DATA_TYPE
 #######################################
 # Constants (LITERAL1)
 #######################################
-Animately           LITERAL1
+Animately	LITERAL1
 
 
 #######################################
 # Preprocessor (PREPROCESSOR)
 #######################################
-TIMELINE_MAX_SCHEDULED_ENTRIES  PREPROCESSOR
-TIMELINE_MAX_ACTIVE_ENTRIES     PREPROCESSOR
-COULD_NOT_ALLOCATE              PREPROCESSOR
-REDUNDANT_ALLOCATION            PREPROCESSOR
-COULD_NOT_SCHEDULE              PREPROCESSOR
-INVALID_INDEX                   PREPROCESSOR
-LOG                             PREPROCESSOR
-LOG_BUFFER_SIZE                 PREPROCESSOR
-LOGF                            PREPROCESSOR
-ERROR                           PREPROCESSOR
-DELEGATE                        PREPROCESSOR
+TIMELINE_MAX_SCHEDULED_ENTRIES	PREPROCESSOR
+TIMELINE_MAX_ACTIVE_ENTRIES	PREPROCESSOR
+COULD_NOT_ALLOCATE	PREPROCESSOR
+REDUNDANT_ALLOCATION	PREPROCESSOR
+COULD_NOT_SCHEDULE	PREPROCESSOR
+INVALID_INDEX	PREPROCESSOR
+LOG	PREPROCESSOR
+LOG_BUFFER_SIZE	PREPROCESSOR
+LOGF	PREPROCESSOR
+ERROR	PREPROCESSOR
+DELEGATE	PREPROCESSOR
 


### PR DESCRIPTION
The Arduino IDE currently requires the use of a single true tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords