### PR TITLE
Add Animatedly.h to library.properties includes field

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Precise animation of props or robots without the need for thread-blocki
 paragraph=Animately allows for precise animation of props or robots, down to the millisecond, without the need for thread-blocking (delay()) or complex state machines. This frees you to focus on the creative aspects of animating rather than the implementation details.
 category=Device Control
 url=https://github.com/nickkoza/animately
-includes=Core/Timeline.h
+includes=Animatedly.h,Core/Timeline.h


### PR DESCRIPTION
The `includes` field in library.properties is used to specify the #include directives which should be automatically added to the sketch after the user selects **Sketch > Include Library > Animatedly**. Previously this action would only add the line:
```cpp
#include <Core/Timeline.h>
```
to the sketch. Thus, Animatedly.h must be one of the values specified in this field.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format