### PR TITLE
Fix filename case in #include directive

### DIFF
--- a/src/Animately.h
+++ b/src/Animately.h
@@ -23,7 +23,7 @@
 #ifndef _Animately_h
 #define _Animately_h
 
-#include "arduino.h"
+#include "Arduino.h"
 
 // CONFIGURATION
 #ifndef TIMELINE_MAX_SCHEDULED_ENTRIES


### PR DESCRIPTION
Incorrect capitalization of Arduino.h caused compilation to fail on filename cause-sensitive operating systems like Linux.